### PR TITLE
PMM-4651 Update Ad SDK to support AdManager instead of AdMob

### DIFF
--- a/ConnectAd_ObjC.podspec
+++ b/ConnectAd_ObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
  s.name             = 'ConnectAd_ObjC'
- s.version          = '1.0.16'
+ s.version          = '1.1'
  s.summary          = 'ConnectAd_ObjC for iOS.'
  s.description      = 'This pod is used for integrating ConnectAd_ObjC in Objective-C iOS projects.'
 

--- a/ConnectAd_ObjC/Classes/ConnectAd.h
+++ b/ConnectAd_ObjC/Classes/ConnectAd.h
@@ -12,12 +12,14 @@ typedef NS_ENUM(NSInteger, AdType) {
     // Vertical
     ADMOB,
     MOPUB,
-    CONNECT
+    CONNECT,
+    ADSMANAGER
 };
 
 typedef enum AdKey {
     admob,
     mopub,
+    adsmanager
 } FormatType;
 
 extern NSString * _Nullable const AdKeyToString[];
@@ -25,7 +27,8 @@ extern NSString * _Nullable const AdKeyToString[];
 typedef enum: int {
     AdMobOrder = 1 ,
     MoPubOrder = 2 ,
-    ConnectOrder = 3
+    ConnectOrder = 3,
+    AdsManagerOrder = 4
 }AdOrder;
 
 @protocol ConnectAdBannerDelegate

--- a/ConnectAd_ObjC/Classes/ConnectAdBanner.h
+++ b/ConnectAd_ObjC/Classes/ConnectAdBanner.h
@@ -12,21 +12,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(strong,nonatomic)UIViewController *rootViewController;
 @property(strong,nonatomic)GADBannerView *adMobBannerView;
+@property(strong,nonatomic)GADBannerView *adsManagerBannerView;
 @property(strong,nonatomic)MPAdView *moPubBannerView;
 @property(strong,nonatomic)ConnectBannerView *connectBannerView;
 @property(strong,nonatomic)NSMutableArray<AdId *> *adMobBanners;
+@property(strong,nonatomic)NSMutableArray<AdId *> *adsManagerBanners;
 @property(strong,nonatomic)NSMutableArray<AdId *> *moPubBanners;
 @property(nonatomic, assign)AdType adType;
 @property(strong,nonatomic)NSString *adMobConnectId;
+@property(strong,nonatomic)NSString *adsManagerConnectId;
 @property(strong,nonatomic)NSString *moPubConnectId;
 @property(strong,nonatomic)NSMutableArray *connectAdBanners;
-@property (assign) id <ConnectAdBannerDelegate> delegate;
+@property (assign) id <ConnectAdBannerDelegate> delegate; 
 -(void)loadAds;
 @property(strong,nonatomic)NSMutableArray *bannerOrders;
 @property(strong,nonatomic)NSMutableArray *adMobConnectIds;
+@property(strong,nonatomic)NSMutableArray *adsManagerConnectIds;
 @property(strong,nonatomic)NSMutableArray *moPubConnectIds;
 
-- (id)initWithAdPosition:(int)position parentView:(UIView*)parentView;
+- (id)initWithAdPosition:(int)position parentView:(UIView*)parentView; 
 
 @end
 

--- a/ConnectAd_ObjC/Classes/ConnectAdInterstitial.h
+++ b/ConnectAd_ObjC/Classes/ConnectAdInterstitial.h
@@ -15,17 +15,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign)AdType adType;
 @property(strong,nonatomic)UIViewController *rootViewController;
 @property(strong,nonatomic)NSString *adMobConnectId;
+@property(strong,nonatomic)NSString *adsManagerConnectId;
 @property(strong,nonatomic)NSString *moPubConnectId;
 @property(strong,nonatomic)NSMutableArray<AdId *> *adMobInterstitials;
+@property(strong,nonatomic)NSMutableArray<AdId *> *adsManagerInterstitials;
 @property(strong,nonatomic)NSMutableArray<AdId *> *moPubInterstitials;
 @property(strong,nonatomic)NSMutableArray *ConnectAdInterstitials;
 @property(strong,nonatomic)GADInterstitial *adMobInterstitial;
+@property(strong,nonatomic)DFPInterstitial *adsManagerInterstitial;
 @property(strong,nonatomic)MPInterstitialAdController *moPubInterstitial;
 @property(strong,nonatomic)NSMutableArray *interstitialOrders;
 @property(strong,nonatomic)NSMutableArray *adMobConnectIds;
+@property(strong,nonatomic)NSMutableArray *adsManagerConnectIds;
 @property(strong,nonatomic)NSMutableArray *moPubConnectIds;
 @property (assign) id <ConnectAdInterstitialDelegate> delegate;
 -(id)init:(NSMutableArray*)adMobIDs :(NSMutableArray*)moPubIDs;
+-(id)init:(NSMutableArray*)adMobIDs :(NSMutableArray*)moPubIDs :(NSMutableArray*)adsManagerIDS;
 -(void)loadFrom: (UIViewController*)viewController;
 
 @end

--- a/ConnectAd_ObjC/Classes/ConnectAdRewarded.h
+++ b/ConnectAd_ObjC/Classes/ConnectAdRewarded.h
@@ -11,17 +11,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ConnectAdRewarded: NSObject<GADRewardBasedVideoAdDelegate, MPRewardedVideoDelegate>
 
 @property(strong,nonatomic)NSString *adMobConnectId;
+@property(strong,nonatomic)NSString *adsManagerConnectId;
 @property(strong,nonatomic)NSString *moPubConnectId;
 @property(strong,nonatomic)UIViewController *rootViewController;
 @property (assign) id <ConnectAdRewardedDelegate> delegate;
 @property(strong,nonatomic)NSMutableArray<AdId *> *adMobRewardeds;
+@property(strong,nonatomic)NSMutableArray<AdId *> *adsManagerRewardeds;
 @property(strong,nonatomic)NSMutableArray<AdId *> *moPubRewardeds;
 @property(nonatomic, assign)AdType adType;
 @property(strong,nonatomic)MPRewardedVideo *PRewardedVideo;
 @property(strong,nonatomic)NSMutableArray *rewardedOrders;
 -(id)init:(NSMutableArray*)adMobIDs :(NSMutableArray*)moPubIDs;
+-(id)init:(NSMutableArray*)adMobIDs :(NSMutableArray*)moPubIDs :(NSMutableArray*)adsManagerIDS;
 -(void)loadFrom: (UIViewController*)viewController;
 @property(strong,nonatomic)NSMutableArray *adMobConnectIds;
+@property(strong,nonatomic)NSMutableArray *adsManagerConnectIds;
 @property(strong,nonatomic)NSMutableArray *moPubConnectIds;
 @end
 


### PR DESCRIPTION
# PMM-4651
(New Feature) [Update Ad SDK to support AdManager instead of AdMob](https://connectedinteractive.atlassian.net/browse/PMM-4651)

### New Feature
Add support to Google Ads Manager in addition to AdMob in Android/iOS native ad sdks.

### Testing
1. Review the source code.
1. Create the app in the Ad SDK dashboard in this [link](http://35.237.243.58/staging/connectedSDK/login) using this credentials. **Username:** Connected@106 and **Password:** Connected@106. You can use test ad unit ids in order to setup the new app from this [link](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/test-ads).
1. Create a brand new iOS project and integrate the SDK into it.
1. Make sure that ads from AdsManager, AdMob and MoPub are showing up (change the demand mapping in the AD SDK dashboard to make sure they you can show ads from all the sources). You should use test ads from AdMob and MoPub from these links:
https://developers.google.com/admob/ios/test-ads
https://developers.mopub.com/publishers/ios/test/

### Thanks
Let me know in case of errors or improvements
#### Marcelo